### PR TITLE
Convert Flask API to FastAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # RPA SISCAN
 
-Este projeto implementa uma automação (RPA) para interação com o sistema SIScan utilizando Playwright e Flask.
+Este projeto implementa uma automação (RPA) para interação com o sistema SIScan utilizando Playwright e FastAPI.
 
 ## Estrutura do projeto
 
-- **run.py** – ponto de entrada que carrega variáveis de ambiente e executa o servidor Flask.
-- **src/main.py** – aplicação Flask com os seguintes endpoints:
+- **run.py** – ponto de entrada que carrega variáveis de ambiente e executa o servidor FastAPI via Uvicorn.
+- **src/main.py** – aplicação FastAPI com os seguintes endpoints:
   - `/cadastrar-usuario` – cadastro de usuários com senha criptografada em SQLite.
   - `/preencher-solicitacao-mamografia` – inicia o RPA para preencher uma solicitação de exame.
   - `/preencher-laudo-mamografia` – inicia o RPA para preencher um laudo de mamografia.
@@ -43,7 +43,7 @@ Para rodar localmente:
 ```bash
 conda create -n siscan python=3.11
 conda activate siscan
-python main.py
+python run.py
 ```
 
 Ou com Docker Compose:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Flask
 cryptography
 playwright
 pytest
@@ -8,3 +7,5 @@ Faker==37.4.0
 validate-docbr==1.11.1
 brazilcep==7.0.0
 fastapi==0.115.13
+uvicorn
+httpx

--- a/run.py
+++ b/run.py
@@ -1,10 +1,11 @@
 from src.main import app
 import logging
+import uvicorn
 
 logging.basicConfig(
     level=logging.DEBUG,  # Troque para logging.INFO caso deseje menos verbosidade
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
 
-if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+if __name__ == '__main__':
+    uvicorn.run(app, host='0.0.0.0', port=5000)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from faker import Faker
 from validate_docbr import CNS
 import brazilcep.client as bc
+from fastapi.testclient import TestClient
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
@@ -39,8 +40,8 @@ from main import app
 def test_db(tmp_path_factory):
     db_path = tmp_path_factory.mktemp("data") / "test.db"
     os.environ["DATABASE_URL"] = str(db_path)
-    import main
-    main.DATABASE = str(db_path)
+    import src.env as env
+    env.DATABASE = str(db_path)
 
     conn = sqlite3.connect(str(db_path))
     conn.execute("""
@@ -55,8 +56,7 @@ def test_db(tmp_path_factory):
 
 @pytest.fixture
 def client(test_db):
-    app.config["TESTING"] = True
-    with app.test_client() as client:
+    with TestClient(app) as client:
         yield client
 
 @pytest.fixture(autouse=True)

--- a/tests/test_preencher_laudo_mamografia.py
+++ b/tests/test_preencher_laudo_mamografia.py
@@ -1,16 +1,16 @@
 import pytest
+from fastapi.testclient import TestClient
 from main import app
 
 @pytest.fixture
 def client():
-    app.config["TESTING"] = True
-    with app.test_client() as client:
+    with TestClient(app) as client:
         yield client
 
 def test_laudo_endpoint(client):
     payload = {"campoA": "valorA", "campoB": "valorB"}
     res = client.post("/preencher-laudo-mamografia", json=payload)
     assert res.status_code == 200
-    data = res.get_json()
+    data = res.json()
     assert data["success"] is True
     assert isinstance(data["screenshots"], list)

--- a/tests/test_preencher_solicitacao_mamografia.py
+++ b/tests/test_preencher_solicitacao_mamografia.py
@@ -1,16 +1,16 @@
 import pytest
+from fastapi.testclient import TestClient
 from main import app
 
 @pytest.fixture
 def client():
-    app.config["TESTING"] = True
-    with app.test_client() as client:
+    with TestClient(app) as client:
         yield client
 
 def test_solicitacao_endpoint(client):
     payload = {"campo1": "valor1", "campo2": "valor2"}
     res = client.post("/preencher-solicitacao-mamografia", json=payload)
     assert res.status_code == 200
-    data = res.get_json()
+    data = res.json()
     assert data["success"] is True
     assert isinstance(data["screenshots"], list)


### PR DESCRIPTION
## Summary
- migrate API implementation from Flask to FastAPI
- run the server with Uvicorn
- adjust tests to use FastAPI TestClient
- document FastAPI usage in README
- update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857d815bf148321a3f790a26041d048