### PR TITLE
Refactor tests and add SQLAlchemy models

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -1,11 +1,13 @@
 import os
-import sqlite3
-
 from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
 load_dotenv()
 
 PRODUCTION = os.getenv("PRODUCTION", "false").lower() == "true"
 TAKE_SCREENSHOT = os.getenv("TAKE_SCREENSHOT", "false").lower() == "true"
+
 DATABASE = os.getenv("DATABASE_URL", "users.db")
 
 SISCAN_URL = os.getenv("SISCAN_URL", "https://siscan.saude.gov.br/")
@@ -14,7 +16,28 @@ SISCAN_URL = os.getenv("SISCAN_URL", "https://siscan.saude.gov.br/")
 SISCAN_USER = os.getenv("SISCAN_USER", "")
 SISCAN_PASSWORD = os.getenv("SISCAN_PASSWORD", "")
 
+Base = declarative_base()
+engine = None
+SessionLocal = None
+
+
+def init_engine(db_path: str | None = None):
+    """Initialize database engine and session factory."""
+    global DATABASE, engine, SessionLocal
+    if db_path is not None:
+        DATABASE = db_path
+    db_url = DATABASE
+    if "://" not in db_url:
+        db_url = f"sqlite:///{db_url}"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    return engine
+
+
+# initialize with default DATABASE on import
+init_engine()
+
+
 def get_db():
-    conn = sqlite3.connect(DATABASE)
-    conn.row_factory = sqlite3.Row
-    return conn
+    """Return a new SQLAlchemy session."""
+    return SessionLocal()

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
-from env import get_db
-from routes import router
 import logging
+from .env import Base, engine
+from .routes import router
+from . import models
 
 logging.basicConfig(
     level=logging.DEBUG,  # Troque para logging.INFO caso deseje menos verbosidade
@@ -10,17 +11,8 @@ logging.basicConfig(
 
 app = FastAPI()
 
-# Cria tabela de usuários se não existir
-conn = get_db()
-conn.execute("""
-CREATE TABLE IF NOT EXISTS users (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    username TEXT UNIQUE NOT NULL,
-    password BLOB NOT NULL
-)
-""")
-conn.commit()
-conn.close()
+# Cria tabelas a partir dos models
+Base.metadata.create_all(bind=engine)
 
 app.include_router(router)
 

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String, LargeBinary
+
+from .env import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, nullable=False)
+    password = Column(LargeBinary, nullable=False)
+

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,5 +1,5 @@
 from playwright.sync_api import sync_playwright
-from env import PRODUCTION, TAKE_SCREENSHOT
+from ..env import PRODUCTION, TAKE_SCREENSHOT
 
 def _run_rpa(form_type, data):
     screenshots = []

--- a/tests/test_preencher_laudo_mamografia.py
+++ b/tests/test_preencher_laudo_mamografia.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-from main import app
+from src.main import app
 
 @pytest.fixture
 def client():

--- a/tests/test_preencher_solicitacao_mamografia.py
+++ b/tests/test_preencher_solicitacao_mamografia.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-from main import app
+from src.main import app
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
## Summary
- move `_run_rpa` helper to `src/utils` and adjust imports
- create SQLAlchemy models and engine initialisation
- update main to create tables with SQLAlchemy
- refactor routes to use SQLAlchemy session and new helper path
- adjust tests for new module structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858018572b88321b7b79c275f5aacd5