### PR TITLE
Centralize message strings in utils.messages

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -5,6 +5,7 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from .env import get_db
 from .models import User
 from .utils.helpers import _run_rpa
+from utils import messages as msg
 
 router = APIRouter()
 
@@ -20,7 +21,7 @@ def cadastrar_usuario(data: dict):
     username = data.get("username")
     password = data.get("password")
     if not username or not password:
-        raise HTTPException(status_code=400, detail="username and password required")
+        raise HTTPException(status_code=400, detail=msg.ERR_USERNAME_PASSWORD_REQUIRED)
 
     encrypted = public_key.encrypt(
         password.encode(),
@@ -36,11 +37,11 @@ def cadastrar_usuario(data: dict):
         db.commit()
     except IntegrityError:
         db.rollback()
-        raise HTTPException(status_code=409, detail="username already exists")
+        raise HTTPException(status_code=409, detail=msg.ERR_USERNAME_EXISTS)
     finally:
         db.close()
 
-    return {"message": "user created"}
+    return {"message": msg.USER_CREATED}
 
 
 @router.post("/preencher-solicitacao-mamografia")

--- a/src/siscan/exception.py
+++ b/src/siscan/exception.py
@@ -1,3 +1,6 @@
+from utils import messages as msg
+
+
 class SiscanException(Exception):
     """
     Exceção base para falhas no SIScan.
@@ -45,7 +48,7 @@ class SiscanLoginError(SiscanException):
     Exceção disparada em caso de falha de login no SIScan.
     """
     def __init__(self, ctx, msg=None):
-        super().__init__(ctx, msg or "Falha na autenticação do SIScan.")
+        super().__init__(ctx, msg or msg.LOGIN_FAIL)
 
 
 class SiscanMenuNotFoundError(SiscanException):
@@ -56,11 +59,11 @@ class SiscanMenuNotFoundError(SiscanException):
         if msg is not None:
             mensagem = msg
         elif menu_name and action:
-            mensagem = f"Menu '{menu_name}' com ação '{action}' não encontrado no SIScan."
+            mensagem = msg.MENU_ACTION_NOT_FOUND(menu_name, action)
         elif menu_name:
-            mensagem = f"Menu '{menu_name}' não encontrado no SIScan."
+            mensagem = msg.MENU_NOT_FOUND(menu_name)
         else:
-            mensagem = "Menu ou ação de menu não encontrado no SIScan."
+            mensagem = msg.MENU_OR_ACTION_NOT_FOUND
         super().__init__(ctx, mensagem)
 
 
@@ -72,9 +75,9 @@ class CartaoSusNotFoundError(SiscanException):
         if msg is not None:
             mensagem = msg
         elif cartao_sus:
-            mensagem = f"Não existe paciente com o Cartão SUS informado: {cartao_sus}."
+            mensagem = msg.CARTAO_SUS_NOT_FOUND_VAL(cartao_sus)
         else:
-            mensagem = "Não existe paciente com o Cartão SUS informado."
+            mensagem = msg.CARTAO_SUS_NOT_FOUND
         super().__init__(ctx, mensagem)
 
 
@@ -87,7 +90,7 @@ class PacienteDuplicadoException(SiscanException):
         if msg is not None:
             mensagem = msg
         else:
-            mensagem = "Foram encontrados múltiplos pacientes na busca. A seleção não pode ser realizada automaticamente."
+            mensagem = msg.MULTIPLE_PATIENTS
         super().__init__(ctx, mensagem)
 
 
@@ -100,11 +103,9 @@ class XpathNotFoundError(SiscanException):
         if msg is not None:
             mensagem = msg
         elif xpath:
-            mensagem = (f"Elemento com XPath '{xpath}' não encontrado "
-                        f"ou não resolvível na página do SIScan.")
+            mensagem = msg.XPATH_NOT_FOUND_VAL(xpath)
         else:
-            mensagem = ("Elemento não encontrado "
-                        "ou não resolvível na página do SIScan.")
+            mensagem = msg.XPATH_NOT_FOUND
         super().__init__(ctx, mensagem)
 
 
@@ -116,9 +117,7 @@ class FieldValueNotFoundError(SiscanException):
     não consta entre as opções disponíveis.
     """
     def __init__(self, context, field_name: str, value, msg: str | None = None):
-        mensagem = (msg or
-            f"Valor '{value}' não encontrado na lista de opções válidas para "
-            f"o campo '{field_name}'.")
+        mensagem = msg or msg.FIELD_VALUE_NOT_FOUND(field_name, value)
         super().__init__(context, msg=mensagem)
         self.field_name = field_name
         self.value = value
@@ -190,14 +189,13 @@ class SiscanInvalidFieldValueError(SiscanException):
                  message: str | None = None
                  ):
         if data and field_name and options_values:
-            msg = (
-                f"O valor '{data.get(field_name)}' "
-                f"fornecido para o campo '{field_name}' não consta na "
-                f"lista de opções válidas. "
-                f"Opções válidas: {', '.join(options_values)}."
+            msg = msg.INVALID_FIELD_VALUE_OPTIONS(
+                field_name,
+                data.get(field_name),
+                options_values,
             )
         elif field_name:
-            msg = f"O campo '{field_name}' deve ser informado."
+            msg = msg.FIELD_REQUIRED(field_name)
         if message:
             msg = message
 

--- a/src/siscan/requisicao_exame_mamografia.py
+++ b/src/siscan/requisicao_exame_mamografia.py
@@ -8,6 +8,7 @@ from src.siscan.exception import CartaoSusNotFoundError
 from src.siscan.requisicao_exame import RequisicaoExame
 from src.siscan.utils.SchemaMapExtractor import SchemaMapExtractor
 from src.siscan.webtools.xpath_constructor import XPathConstructor
+from utils import messages as msg
 
 logger = logging.getLogger(__name__)
 
@@ -133,9 +134,7 @@ class RequisicaoExameMamografia(RequisicaoExame):
             label_dependentes={
                 "ano_que_fez_a_ultima_mamografia": "Ano:",
             },
-            erro_dependente_msg=(
-                "Campos 'Ano' de 'QUANDO FEZ A ÚLTIMA MAMOGRAFIA?' do card "
-                "'FEZ MAMOGRAFIA ALGUMA VEZ?' é obrigatório.")
+            erro_dependente_msg=msg.ANO_MAMOGRAFIA_REQUIRED
         )
 
     def preenche_fez_radioterapia_na_mama_ou_no_plastao(self, data: dict):
@@ -159,8 +158,7 @@ class RequisicaoExameMamografia(RequisicaoExame):
                     "ano_da_radioterapia_esquerda":
                         "Ano da Radioterapia - Esquerda:",
                 },
-                erro_dependente_msg="Campos de ano da radioterapia "
-                                    "obrigatórios conforme a localização."
+                erro_dependente_msg=msg.ANO_RADIOTERAPIA_REQUIRED
             )
 
     def preenche_fez_cirurgia_cirurgica(self, data: dict):
@@ -186,8 +184,10 @@ class RequisicaoExameMamografia(RequisicaoExame):
 
         # Verifica se o Cartão SUS foi informado
         if not data.get("cartao_sus"):
-            raise CartaoSusNotFoundError(self.context,
-                                         "Cartão SUS não informado.")
+            raise CartaoSusNotFoundError(
+                self.context,
+                msg.CARTAO_SUS_NAO_INFORMADO,
+            )
         super().preencher(data)
 
         xpath = XPathConstructor(self.context)

--- a/src/siscan/siscan_webpage.py
+++ b/src/siscan/siscan_webpage.py
@@ -19,6 +19,7 @@ from src.siscan.utils.validator import Validator, SchemaValidationError
 from utils.schema import create_model_from_json_schema
 from src.siscan.webtools.webpage import WebPage
 from src.siscan.webtools.xpath_constructor import XPathConstructor
+from utils import messages as msg
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +179,7 @@ class SiscanWebPage(WebPage):
                 self.context,
                 menu_name=menu_name,
                 action=menu_action_text,
-                msg="Menu não localizado após múltiplas tentativas.",
+                msg=msg.MENU_ACCESS_TIMEOUT,
             )
         )
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .messages import *

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,3 +1,4 @@
+# Validation messages
 E_REQUIRED = lambda f: f"Campo '{f}' obrigat\u00f3rio"
 E_PATTERN = lambda f, v, p: f"Campo '{f}' com valor '{v}' n\u00e3o corresponde ao padr\u00e3o '{p}'"
 E_ENUM = lambda f, v, opts: f"Campo '{f}' com valor '{v}' n\u00e3o est\u00e1 entre os valores permitidos: {opts}"
@@ -9,3 +10,38 @@ E_MAX_ITEMS = lambda f, v, inst: (
 )
 M_001 = "Opera\u00e7\u00e3o conclu\u00edda"
 W_001 = "Aviso"
+
+# API messages
+USER_CREATED = "user created"
+ERR_USERNAME_PASSWORD_REQUIRED = "username and password required"
+ERR_USERNAME_EXISTS = "username already exists"
+
+# Exception messages
+LOGIN_FAIL = "Falha na autentica\u00e7\u00e3o do SIScan."
+MENU_ACTION_NOT_FOUND = lambda menu, action: f"Menu '{menu}' com a\u00e7\u00e3o '{action}' n\u00e3o encontrado no SIScan."
+MENU_NOT_FOUND = lambda menu: f"Menu '{menu}' n\u00e3o encontrado no SIScan."
+MENU_OR_ACTION_NOT_FOUND = "Menu ou ac\u00e7\u00e3o de menu n\u00e3o encontrado no SIScan."
+CARTAO_SUS_NOT_FOUND_VAL = lambda cs: f"N\u00e3o existe paciente com o Cart\u00e3o SUS informado: {cs}."
+CARTAO_SUS_NOT_FOUND = "N\u00e3o existe paciente com o Cart\u00e3o SUS informado."
+MULTIPLE_PATIENTS = (
+    "Foram encontrados m\u00faltiplos pacientes na busca. A sele\u00e7\u00e3o n\u00e3o pode ser realizada automaticamente."
+)
+XPATH_NOT_FOUND_VAL = lambda xp: f"Elemento com XPath '{xp}' n\u00e3o encontrado ou n\u00e3o resolv\u00edvel na p\u00e1gina do SIScan."
+XPATH_NOT_FOUND = "Elemento n\u00e3o encontrado ou n\u00e3o resolv\u00edvel na p\u00e1gina do SIScan."
+FIELD_VALUE_NOT_FOUND = lambda field, value: (
+    f"Valor '{value}' n\u00e3o encontrado na lista de op\u00e7\u00f5es v\u00e1lidas para o campo '{field}'."
+)
+INVALID_FIELD_VALUE_OPTIONS = lambda field, value, opts: (
+    f"O valor '{value}' fornecido para o campo '{field}' n\u00e3o consta na lista de op\u00e7\u00f5es v\u00e1lidas. Op\u00e7\u00f5es v\u00e1lidas: {', '.join(opts)}."
+)
+FIELD_REQUIRED = lambda field: f"O campo '{field}' deve ser informado."
+
+# Other domain messages
+MENU_ACCESS_TIMEOUT = "Menu n\u00e3o localizado ap\u00f3s m\u00faltiplas tentativas."
+ANO_MAMOGRAFIA_REQUIRED = (
+    "Campos 'Ano' de 'QUANDO FEZ A \u00daLTIMA MAMOGRAFIA?' do card 'FEZ MAMOGRAFIA ALGUMA VEZ?' \u00e9 obrigat\u00f3rio."
+)
+ANO_RADIOTERAPIA_REQUIRED = "Campos de ano da radioterapia obrigat\u00f3rios conforme a localiza\u00e7\u00e3o."
+CARTAO_SUS_NAO_INFORMADO = "Cart\u00e3o SUS n\u00e3o informado."
+
+__all__ = [name for name in globals() if name.isupper()]


### PR DESCRIPTION
## Summary
- centralize all user-facing messages in `utils/messages.py`
- export messages for easier import via `utils` package
- refactor FastAPI routes and exceptions to use the constants
- link mamografia workflows to new message constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685824cb642c8321b3eba414b00248cb