### PR TITLE
Fix typing warnings

### DIFF
--- a/src/siscan/exception.py
+++ b/src/siscan/exception.py
@@ -1,3 +1,4 @@
+from typing import Iterable
 from utils import messages as msg
 
 
@@ -6,7 +7,7 @@ class SiscanException(Exception):
     Exceção base para falhas no SIScan.
     Permite extrair mensagens de erro da página Playwright.
     """
-    def __init__(self, ctx, msg=None):
+    def __init__(self, ctx, msg: str | None = None):
         self.ctx = ctx
         self.msg = msg or ""
         if ctx is not None:
@@ -55,7 +56,8 @@ class SiscanMenuNotFoundError(SiscanException):
     """
     Exceção disparada quando um menu ou ação de menu não é encontrado no SIScan.
     """
-    def __init__(self, ctx, menu_name: str = None, action: str = None, msg: str = None):
+    def __init__(self, ctx, menu_name: str | None = None,
+                 action: str | None = None, msg: str | None = None):
         if msg is not None:
             mensagem = msg
         elif menu_name and action:
@@ -71,7 +73,7 @@ class CartaoSusNotFoundError(SiscanException):
     """
     Exceção disparada quando o Cartão SUS informado não é localizado no SIScan.
     """
-    def __init__(self, ctx, cartao_sus: str = None, msg: str = None):
+    def __init__(self, ctx, cartao_sus: str | None = None, msg: str | None = None):
         if msg is not None:
             mensagem = msg
         elif cartao_sus:
@@ -86,7 +88,7 @@ class PacienteDuplicadoException(SiscanException):
     Exceção disparada quando mais de um paciente é encontrado na busca do SIScan,
     impossibilitando a seleção automática e exigindo intervenção manual.
     """
-    def __init__(self, ctx, msg: str = None):
+    def __init__(self, ctx, msg: str | None = None):
         if msg is not None:
             mensagem = msg
         else:
@@ -99,7 +101,7 @@ class XpathNotFoundError(SiscanException):
     Exceção disparada quando um elemento (Locator) não é encontrado ou
     não pode ser resolvido na página do SIScan.
     """
-    def __init__(self, ctx, xpath: str = None, msg: str = None):
+    def __init__(self, ctx, xpath: str | None = None, msg: str | None = None):
         if msg is not None:
             mensagem = msg
         elif xpath:
@@ -173,9 +175,9 @@ class SiscanInvalidFieldValueError(SiscanException):
     data : dict, opcional
         Dicionário de dados submetidos, utilizado para identificar o valor
         problemático.
-    options_values : list, opcional
-        Lista de valores válidos para o campo, utilizada para construção
-        da mensagem de erro.
+    options_values : Iterable[str], opcional
+        Coleção de valores válidos para o campo, utilizada para
+        construção da mensagem de erro.
     message : str, opcional
         Mensagem customizada de erro. Se fornecida, sobrescreve as
         mensagens padrão.
@@ -185,7 +187,7 @@ class SiscanInvalidFieldValueError(SiscanException):
     def __init__(self, context,
                  field_name: str | None = None,
                  data: dict | None = None,
-                 options_values: list | None = None,
+                 options_values: Iterable[str] | None = None,
                  message: str | None = None
                  ):
         if data and field_name and options_values:

--- a/src/siscan/requisicao_exame.py
+++ b/src/siscan/requisicao_exame.py
@@ -10,6 +10,7 @@ from src.siscan.exception import SiscanInvalidFieldValueError
 from src.siscan.siscan_webpage import SiscanWebPage
 from src.siscan.utils.SchemaMapExtractor import SchemaMapExtractor
 from src.siscan.webtools.xpath_constructor import XPathConstructor, InputType
+from src.siscan.webtools.webpage import RequirementLevel
 
 logger = logging.getLogger(__name__)
 
@@ -46,19 +47,24 @@ class RequisicaoExame(SiscanWebPage):
         raise NotImplementedError("O método select_type_exam deve ser "
                                   "implementado na subclasse.")
 
-    def get_map_label(self) -> dict[str, tuple[str, str]]:
+    def get_map_label(self) -> dict[str, tuple[str, str, str]]:
         """
         Retorna o mapeamento de campos do formulário com seus respectivos
         labels e tipos.
 
         Retorna
         -------
-        dict[str, tuple[str, str]]
+        dict[str, tuple[str, str, str]]
             Dicionário onde a chave é o nome do campo e o valor é uma tupla
-            contendo o label e o tipo do campo.
+            contendo o label, o tipo do campo e o nível de
+            obrigatoriedade.
         """
         return {
-            "cartao_sus": ("Cartão SUS", InputType.TEXT),
+            "cartao_sus": (
+                "Cartão SUS",
+                InputType.TEXT,
+                RequirementLevel.REQUIRED,
+            ),
             **RequisicaoExame.MAP_DATA_LABEL,
         }
 

--- a/src/siscan/requisicao_exame_mamografia.py
+++ b/src/siscan/requisicao_exame_mamografia.py
@@ -8,6 +8,7 @@ from src.siscan.exception import CartaoSusNotFoundError
 from src.siscan.requisicao_exame import RequisicaoExame
 from src.siscan.utils.SchemaMapExtractor import SchemaMapExtractor
 from src.siscan.webtools.xpath_constructor import XPathConstructor
+from src.siscan.webtools.webpage import RequirementLevel
 from utils import messages as msg
 
 logger = logging.getLogger(__name__)
@@ -87,16 +88,16 @@ class RequisicaoExameMamografia(RequisicaoExame):
 
         super().validation(data)
 
-    def get_map_label(self) -> dict[str, tuple[str, str]]:
+    def get_map_label(self) -> dict[str, tuple[str, str, str]]:
         """
         Retorna o mapeamento de campos do formulário com seus respectivos
         labels e tipos, específico para o exame de Mamografia.
 
         Retorna
         -------
-        dict[str, tuple[str, str]]
+        dict[str, tuple[str, str, str]]
             Dicionário onde a chave é o nome do campo e o valor é uma tupla
-            contendo o label e o tipo do campo.
+            contendo o label, o tipo do campo e o nível de obrigatoriedade.
         """
         map_label = {
             **RequisicaoExameMamografia.MAP_DATA_LABEL,
@@ -210,7 +211,7 @@ class RequisicaoExameMamografia(RequisicaoExame):
 
         self.take_screenshot("screenshot_04_requisicao_exame_mamografia.png")
 
-    def preencher_ano_cirurgia(self, data: str,):
+    def preencher_ano_cirurgia(self, data: dict):
         anos_procedimentos = [
             "ano_biopsia_cirurgica_incisional_direita",
             "ano_biopsia_cirurgica_incisional_esquerda",

--- a/src/siscan/webtools/webpage.py
+++ b/src/siscan/webtools/webpage.py
@@ -62,7 +62,7 @@ class WebPage(ABC):
         raise NotImplementedError("Subclasses devem implementar este método.")
 
     @abstractmethod
-    def get_map_label(self) -> dict[str, tuple[str, str]]:
+    def get_map_label(self) -> dict[str, tuple[str, str, str]]:
         """
         Método abstrato que deve ser implementado por subclasses para retornar
         o mapeamento de labels. Deve retornar um dicionário onde as chaves
@@ -96,7 +96,7 @@ class WebPage(ABC):
         ----------
         field_name : str
             Nome lógico do campo para o qual se deseja obter as informações.
-        map_label : Optional[dict[str, tuple]], opcional
+        map_label : Optional[dict[str, tuple[str, str, str]]], opcional
             Dicionário de mapeamento de campos. Caso não seja informado,
             utiliza o mapeamento padrão retornado por `get_map_label()`.
 
@@ -142,7 +142,7 @@ class WebPage(ABC):
 
     def get_field_label(
             self, field_name: str,
-            map_label: Optional[dict[str, tuple[str, str]]] = None) -> str:
+            map_label: Optional[dict[str, tuple[str, str, str]]] = None) -> str:
         """
         Retorna o texto do label associado ao nome lógico do campo, com base no
         mapeamento informado.
@@ -157,7 +157,7 @@ class WebPage(ABC):
         ----------
         campo : str
             Nome lógico do campo para o qual se deseja obter o label.
-        map_label : Optional[dict[str, tuple[str, str]]], opcional
+        map_label : Optional[dict[str, tuple[str, str, str]]], opcional
             Dicionário de mapeamento de campos. Caso não seja informado,
             utiliza o mapeamento padrão retornado por `get_map_label()`.
 
@@ -190,7 +190,7 @@ class WebPage(ABC):
 
     def get_field_type(
             self, field_name: str,
-            map_label: Optional[dict[str, tuple[str, str]]] = None) -> str:
+            map_label: Optional[dict[str, tuple[str, str, str]]] = None) -> str:
         """
         Retorna o tipo de campo associado ao nome lógico do campo, com base no
         mapeamento informado.
@@ -205,7 +205,7 @@ class WebPage(ABC):
         ----------
         campo : str
             Nome lógico do campo para o qual se deseja obter o tipo.
-        map_label : Optional[dict[str, tuple[str, str]]], opcional
+        map_label : Optional[dict[str, tuple[str, str, str]]], opcional
             Dicionário de mapeamento de campos. Caso não seja informado,
             utiliza o mapeamento padrão retornado por `get_map_label()`.
 
@@ -239,7 +239,7 @@ class WebPage(ABC):
 
     def get_field_required(
             self, field_name: str,
-            map_label: Optional[dict[str, tuple[str, str]]] = None) -> str:
+            map_label: Optional[dict[str, tuple[str, str, str]]] = None) -> str:
         if map_label is None:
             value = self.get_map_label().get(field_name)
         else:
@@ -342,9 +342,9 @@ class WebPage(ABC):
 
     def mount_fields_map_and_data(
             self, data: dict,
-            map_label: dict[str, tuple[str, str]],
+            map_label: dict[str, tuple[str, str, str]],
             suffix: Optional[str] = ":"
-    ) -> tuple[dict[str, tuple[str, str]], dict[str, str]]:
+    ) -> tuple[dict[str, tuple[str, str, str]], dict[str, str]]:
         """
         Gera o dicionário campos_map e o dicionário data_final para uso em
         preenchimento genérico de formulários.
@@ -353,15 +353,15 @@ class WebPage(ABC):
         ----------
         data : dict
             Dicionário de dados originais (nomes de campos como chave).
-        map_label : dict[str, tuple[str, str]]
+        map_label : dict[str, tuple[str, str, str]]
             Dicionário com nomes de campos como chave e tuplas contendo
-            (label, tipo de campo) como valor.
+            (label, tipo de campo, requirement_level) como valor.
         suffix : str, opcional (default=":")
 
         Retorna
         -------
         tuple (campos_map, data_final)
-            - campos_map: dict[str, tuple[str, str]]
+            - campos_map: dict[str, tuple[str, str, str]]
             - data_final: dict[str, str]
         """
         if suffix is None:

--- a/src/siscan/webtools/xpath_constructor.py
+++ b/src/siscan/webtools/xpath_constructor.py
@@ -894,7 +894,7 @@ class XPathConstructor:
         logger.debug(f"XPath: {self}")
         return self
 
-    def fill(self, value: str, input_type: str | InputType = None,
+    def fill(self, value: str | list | None, input_type: str | InputType = None,
              timeout: float = DEFAULT_TIMEOUT,
              reset=True) -> 'XPathConstructor':
         """
@@ -915,9 +915,9 @@ class XPathConstructor:
 
         Parâmetros
         ----------
-        value : str
+        value : str | list | None
             Valor a ser preenchido no campo (ou lista de valores para
-            checkboxes).
+            checkboxes). Pode ser None para campos opcionais.
         type_input : str, opcional
             Tipo do campo ('texto', 'select', 'checkbox', 'radio', 'lista').
             O padrão é 'texto'.
@@ -1086,10 +1086,12 @@ class XPathConstructor:
         logger.debug(f"XPath do botão <a> localizado: {self._xpath}")
         return self
 
-    def click(self,
-              timeout: float = DEFAULT_TIMEOUT,
-              interval: float = None,
-              wait_for_selector: str = None, reset=True) -> 'XPathConstructor':
+    def click(
+            self,
+            timeout: float = DEFAULT_TIMEOUT,
+            interval: float | None = None,
+            wait_for_selector: str | None = None,
+            reset=True) -> 'XPathConstructor':
         """
         Realiza o clique forçado no elemento localizado pelo XPath corrente,
         repetindo tentativas até sucesso ou atingir o tempo limite. Se
@@ -1112,7 +1114,7 @@ class XPathConstructor:
             Intervalo, em segundos, entre cada tentativa de clique.
         reset : bool, opcional (default=True)
             Se True, reseta o XPath interno após o clique bem-sucedido.
-        wait_for_selector : str, opcional (default=None)
+        wait_for_selector : str | None, opcional (default=None)
             Se definido, após o clique o método aguardará até o seletor CSS ou
             XPath informado estar presente e visível.
 


### PR DESCRIPTION
## Summary
- improve optional string annotations
- adjust map label typing
- allow iterable options for invalid value error
- relax value type for XPath fill
- update click helper for optional selector

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582a9abd2c8321a7608968f06af3c1