### PR TITLE
Switch to async Playwright

### DIFF
--- a/src/routes.py
+++ b/src/routes.py
@@ -4,7 +4,7 @@ from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from .env import get_db
 from .models import User
-from .utils.helpers import _run_rpa
+from .utils.helpers import run_rpa
 from utils import messages as msg
 
 router = APIRouter()
@@ -56,9 +56,9 @@ def cadastrar_usuario(data: dict):
     summary="Preencher Solicitação de Mamografia",
     description="Executa o RPA para preencher a solicitação de mamografia no SIScan",
 )
-def preencher_solicitacao(data: dict):
+async def preencher_solicitacao(data: dict):
     """Preencher automaticamente a solicitação de mamografia no SIScan."""
-    result = _run_rpa("solicitacao", data)
+    result = await run_rpa("solicitacao", data)
     return result
 
 
@@ -67,7 +67,7 @@ def preencher_solicitacao(data: dict):
     summary="Preencher Laudo de Mamografia",
     description="Executa o RPA para preencher o laudo de mamografia no SIScan",
 )
-def preencher_laudo(data: dict):
+async def preencher_laudo(data: dict):
     """Preencher automaticamente o laudo de mamografia no SIScan."""
-    result = _run_rpa("laudo", data)
+    result = await run_rpa("laudo", data)
     return result

--- a/src/scrapping.py
+++ b/src/scrapping.py
@@ -1,6 +1,6 @@
 from src.siscan.utils.validator import Validator
 from pathlib import Path
-
+import asyncio
 from src.env import SISCAN_URL, SISCAN_USER, SISCAN_PASSWORD
 import logging
 
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 # python -m src.siscan.scrapping
-def main():
+async def main():
     current_path = Path(__file__).resolve()
     root_path = current_path.parent.parent
 
@@ -26,7 +26,7 @@ def main():
 
     # requisicao.buscar_cartao_sus(dados)
 
-    requisicao.preencher(dados)
+    await asyncio.to_thread(requisicao.preencher, dados)
 
     informations = requisicao.context.information_messages
     if informations:
@@ -38,6 +38,5 @@ def main():
 
     requisicao.context.close()
 
-
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,11 +1,13 @@
-from playwright.sync_api import sync_playwright
+import asyncio
+from playwright.async_api import async_playwright
 from ..env import PRODUCTION, TAKE_SCREENSHOT
 
-def _run_rpa(form_type, data):
+async def run_rpa(form_type, data):
+    """Executa o fluxo do RPA utilizando Playwright assíncrono."""
     screenshots = []
-    with sync_playwright() as p:
-        browser = p.chromium.launch(headless=not PRODUCTION)
-        page = browser.new_page()
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=not PRODUCTION)
+        page = await browser.new_page()
         # TODO: implementar login no SISCAN usando CPF/senha de users db
 
         # TODO: navegar até o formulário e preencher campos com 'data'
@@ -14,12 +16,13 @@ def _run_rpa(form_type, data):
         if not PRODUCTION and TAKE_SCREENSHOT:
             for i in range(1, 4):
                 path = f"static/tmp/{form_type}_step{i}.png"
-                page.screenshot(path=path)
+                await page.screenshot(path=path)
                 screenshots.append(path)
 
         if PRODUCTION:
-            page.click("button[type=submit]")
+            await page.click("button[type=submit]")
 
-        browser.close()
+        await browser.close()
 
     return {"success": True, "screenshots": screenshots}
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,10 +49,10 @@ def client(test_db):
 
 @pytest.fixture(autouse=True)
 def mock_run_rpa(monkeypatch):
-    def fake_run_rpa(form_type, data):
+    async def fake_run_rpa(form_type, data):
         return {"success": True, "screenshots": []}
 
-    monkeypatch.setattr("src.routes._run_rpa", fake_run_rpa)
+    monkeypatch.setattr("src.routes.run_rpa", fake_run_rpa)
 
 @pytest.fixture(scope="session")
 def fake_json_file(tmp_path_factory):


### PR DESCRIPTION
## Summary
- make helper for RPA asynchronous using `async_playwright`
- update FastAPI endpoints to call async helper
- run scrapping module through `asyncio`
- adjust tests to patch new async helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858470615c08321b1731c63b50f96c5