### PR TITLE
Refactor context to use async Playwright

### DIFF
--- a/src/siscan/webtools/xpath_constructor.py
+++ b/src/siscan/webtools/xpath_constructor.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 import time
 import logging
-from playwright.sync_api import Page, Locator, TimeoutError, ElementHandle
+from playwright.async_api import Page, Locator, TimeoutError, ElementHandle
 from src.siscan.context import SiscanBrowserContext
 from src.siscan.exception import SiscanMenuNotFoundError, \
     XpathNotFoundError, SiscanException


### PR DESCRIPTION
## Summary
- switch SiscanBrowserContext to async Playwright
- wrap async Playwright objects for sync-style use
- update XPath constructor to import from async API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859474dac488321ba884cbf87add5f4