### PR TITLE
Add Playwright integration tests for form inputs

### DIFF
--- a/tests/test_xpath_input_types.py
+++ b/tests/test_xpath_input_types.py
@@ -1,0 +1,61 @@
+import pytest
+from src.siscan.requisicao_exame_mamografia import RequisicaoExameMamografia
+from src.siscan.webtools.xpath_constructor import XPathConstructor, InputType
+from src.siscan.utils.validator import Validator
+from src.env import SISCAN_URL, SISCAN_USER, SISCAN_PASSWORD
+
+
+@pytest.fixture(scope="session")
+def siscan_form():
+    """Autentica no SIScan e navega até o formulário de novo exame."""
+    req = RequisicaoExameMamografia(
+        url_base=SISCAN_URL,
+        user=SISCAN_USER,
+        password=SISCAN_PASSWORD,
+    )
+    req.authenticate()
+    req._novo_exame(event_button=True)
+    yield req
+    req.context.close()
+
+
+def _load_data(path):
+    return Validator.load_json(path)
+
+
+def test_fill_text_input(siscan_form, fake_json_file):
+    data = _load_data(fake_json_file)
+    xpath = XPathConstructor(siscan_form.context)
+    label = siscan_form.get_field_label("nome")
+    xpath.find_form_input(label, InputType.TEXT).fill(data["nome"], reset=False)
+    text, value = xpath.get_value(InputType.TEXT)
+    assert value == data["nome"]
+
+
+def test_fill_select_input(siscan_form, fake_json_file):
+    data = _load_data(fake_json_file)
+    xpath = XPathConstructor(siscan_form.context)
+    label = siscan_form.get_field_label("nacionalidade")
+    xpath.find_form_input(label, InputType.SELECT).fill(data["nacionalidade"], reset=False)
+    text, value = xpath.get_value(InputType.SELECT)
+    assert value is not None
+
+
+def test_fill_date_input(siscan_form, fake_json_file):
+    data = _load_data(fake_json_file)
+    xpath = XPathConstructor(siscan_form.context)
+    label = siscan_form.get_field_label("data_de_nascimento")
+    xpath.find_form_input(label, InputType.DATE).fill(data["data_de_nascimento"], reset=False)
+    text, value = xpath.get_value(InputType.DATE)
+    assert value == data["data_de_nascimento"]
+
+
+def test_fill_checkbox_input(siscan_form, fake_json_file):
+    data = _load_data(fake_json_file)
+    xpath = XPathConstructor(siscan_form.context)
+    label = siscan_form.get_field_label("tem_nodulo_ou_caroco_na_mama")
+    valores = data["tem_nodulo_ou_caroco_na_mama"]
+    xpath.find_form_input(label, InputType.CHECKBOX).fill(valores, reset=False)
+    result = xpath.get_value(InputType.CHECKBOX)
+    assert isinstance(result, list)
+    assert len(result) == len(valores)


### PR DESCRIPTION
## Summary
- add integration tests covering text, select, date and checkbox fields
- create fixture to authenticate into SIScan and open the exam form

## Testing
- `pytest -k test_xpath_input_types -q` *(fails: BrowserType.launch: Target page...)*

------
https://chatgpt.com/codex/tasks/task_e_685948ea2c6c8321818bb1777c842ba6