### PR TITLE
Add test for Siscan login

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Flask
 cryptography
 playwright
 pytest
+pytest-playwright
 python-dotenv==1.1.0

--- a/tests/test_authenticate.py
+++ b/tests/test_authenticate.py
@@ -1,0 +1,26 @@
+import os
+import pytest
+from src.siscan.requisicao_exame_mamografia import RequisicaoExameMamografia
+from src.siscan.context import SiscanBrowserContext
+
+
+def test_authenticate(monkeypatch):
+    monkeypatch.setenv("SISCAN_USER", "dummy@example.com")
+    monkeypatch.setenv("SISCAN_PASSWORD", "dummy")
+
+    requisicao = RequisicaoExameMamografia(
+        url_base=os.getenv("SISCAN_URL", "https://siscan.saude.gov.br/"),
+        user=os.getenv("SISCAN_USER"),
+        password=os.getenv("SISCAN_PASSWORD"),
+    )
+    # Use contexto headless para nao abrir janela durante testes
+    requisicao._context = SiscanBrowserContext(
+        url_base=requisicao._url_base,
+        headless=True,
+        timeout=15000,
+    )
+
+    requisicao.authenticate()
+    assert requisicao.context.page.locator(
+        'h1:text("SEJA BEM VINDO AO SISCAN")'
+    ).is_visible()


### PR DESCRIPTION
## Summary
- add pytest-playwright to dependencies
- test authentication workflow with Playwright

## Testing
- `PYTHONPATH=src pytest -q` *(fails: FileNotFoundError: rsa_private_key.pem)*

------
https://chatgpt.com/codex/tasks/task_e_6859579ee13c8321b3f447d7fd83f117