### PR TITLE
Add debug logging for Playwright startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,14 @@ python -m src.scrapping # rodar o scrapping
 ```
 
 ## Rodando testes
+Instale os navegadores do Playwright uma vez antes de rodar os testes:
 
 ```bash
-pytest
+playwright install
+```
+
+Para visualizar as mensagens de `print` e `logger.debug` utilize a flag `-s`:
+
+```bash
+pytest -s
 ```

--- a/src/siscan/context.py
+++ b/src/siscan/context.py
@@ -142,11 +142,20 @@ class SiscanBrowserContext:
             return self._browser, self._page
 
         async def _launch():
-            playwright = await async_playwright().start()
-            browser = await playwright.chromium.launch(headless=self.headless)
-            page = await browser.new_page()
-            await page.goto(self._url_base, wait_until="load")
-            return playwright, browser, page
+            logger.debug("Inicializando Playwright")
+            try:
+                playwright = await async_playwright().start()
+                logger.debug("Abrindo navegador Chromium")
+                browser = await playwright.chromium.launch(headless=self.headless)
+                page = await browser.new_page()
+                await page.goto(self._url_base, wait_until="load")
+                return playwright, browser, page
+            except Exception:
+                logger.exception(
+                    "Falha ao iniciar o navegador do Playwright. "
+                    "Certifique-se de que os browsers estao instalados com 'playwright install'."
+                )
+                raise
 
         self._playwright, browser, page = asyncio.run(_launch())
         self._browser = _SyncWrapper(browser)

--- a/src/siscan/siscan_webpage.py
+++ b/src/siscan/siscan_webpage.py
@@ -95,6 +95,7 @@ class SiscanWebPage(WebPage):
         Exception se autenticação falhar.
         """
 
+        logger.debug("Autenticando usuario %s", self._user)
         self.context.goto("/login.jsf", wait_until="load")
 
         # Aguarda possível popup abrir e fecha se necessário


### PR DESCRIPTION
## Summary
- add debug message when authenticating
- log Playwright startup and errors in `SiscanBrowserContext`
- update README with tips on installing browsers and using `pytest -s`

## Testing
- `pytest -k authenticate -vvv -s` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68595b5b432c8321849025aa2206468e