### PR TITLE
Fix async initialization and button handling

### DIFF
--- a/src/siscan/requisicao_exame.py
+++ b/src/siscan/requisicao_exame.py
@@ -74,9 +74,11 @@ class RequisicaoExame(SiscanWebPage):
     async def _novo_exame(self, event_button: bool = False) -> XPathConstructor:
         await self.acesar_menu_gerenciar_exame()
 
+        xpath = XPathConstructor(self.context)
         if event_button:
-
-            xpath = XPathConstructor(self.context)
+            # ``find_form_anchor_button`` é síncrono e apenas configura o XPath
+            # interno. O clique propriamente dito é assíncrono, portanto
+            # chamamos ``handle_click`` e aguardamos sua conclusão.
             await xpath.find_form_anchor_button("Novo Exame").handle_click()
 
         await xpath.wait_page_ready()

--- a/src/utils/webpage.py
+++ b/src/utils/webpage.py
@@ -55,7 +55,8 @@ class WebPage(ABC):
             headless=False,  # Para depuração, use False
             timeout=15000,
         )
-        self.authenticate()
+        # A autenticação requer chamadas assíncronas, por isso é responsabilidade
+        # de quem utilizar esta classe chamar ``authenticate`` explicitamente.
 
     @abstractmethod
     def authenticate(self):


### PR DESCRIPTION
## Summary
- adjust context initialization to not implicitly run authentication
- correct new exam helper to avoid double `await` and document

## Testing
- `pytest tests/test_validator.py -q`
- `pytest tests/test_xpath_input_types.py::test_fill_text_input -q` *(fails: BrowserType.launch: Target page, context or browser has been closed)*

------
https://chatgpt.com/codex/tasks/task_e_6859a0be86bc8321a7226d4b9d6f17a7