### PR TITLE
Split Playwright flow into separate test file

### DIFF
--- a/tests/test_playwright_flow.py
+++ b/tests/test_playwright_flow.py
@@ -1,0 +1,54 @@
+import logging
+import pytest
+import pytest_asyncio
+from playwright.async_api import async_playwright, Page
+
+from src.utils.validator import Validator
+from src.env import SISCAN_URL, SISCAN_USER, SISCAN_PASSWORD
+
+logger = logging.getLogger(__name__)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def playwright_page():
+    """Cria contexto Playwright manualmente e autentica no SIScan."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        context = await browser.new_context(base_url=SISCAN_URL)
+        page = await context.new_page()
+
+        await page.goto("/login.jsf")
+        await page.get_by_label("E-mail").fill(SISCAN_USER)
+        await page.get_by_label("Senha").fill(SISCAN_PASSWORD)
+        await page.get_by_role("button", name="Acessar").click()
+        await page.wait_for_selector("text=SEJA BEM VINDO AO SISCAN")
+
+        # Navega pelo menu até a opção Novo Exame
+        await page.locator(
+            ".rich-ddmenu-label .rich-label-text-decor",
+            has_text="EXAME",
+        ).first.hover()
+        await page.locator(
+            ".rich-menu-item-label",
+            has_text="GERENCIAR EXAME",
+        ).click()
+        await page.locator("a.form-button", has_text="Novo Exame").click()
+        await page.wait_for_selector("label:has-text('Unidade Requisitante')")
+
+        yield page
+        await browser.close()
+
+
+@pytest.mark.asyncio
+async def test_preencher_campos_metodo_playwright(playwright_page: Page, fake_json_file):
+    page = playwright_page
+    data = Validator.load_json(fake_json_file)
+
+    await page.get_by_label("Cartão SUS").fill(data["cartao_sus"])
+    await page.get_by_label('Mamografia').check()
+    select = page.get_by_label('Unidade Requisitante')
+    logger.debug(select)
+
+    await select.wait_for(state='attached', timeout=5000)
+    await select.select_option(label='0274267 - CENTRAL DE TELEATENDIMENTO SAUDE JA CURITIBA')
+

--- a/tests/test_xpath_input_types.py
+++ b/tests/test_xpath_input_types.py
@@ -1,6 +1,5 @@
 import pytest
 import pytest_asyncio
-from playwright.async_api import async_playwright, Page
 from src.siscan.requisicao_exame_mamografia import RequisicaoExameMamografia
 from src.utils.xpath_constructor import XPathConstructor, InputType
 from src.utils.validator import Validator
@@ -30,50 +29,8 @@ async def siscan_form():
     req.context.close()
 
 
-@pytest_asyncio.fixture(scope="session")
-async def playwright_page():
-    """Cria contexto Playwright manualmente e autentica no SIScan."""
-    async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
-        context = await browser.new_context(base_url=SISCAN_URL)
-        page = await context.new_page()
-
-        await page.goto("/login.jsf")
-        await page.get_by_label("E-mail").fill(SISCAN_USER)
-        await page.get_by_label("Senha").fill(SISCAN_PASSWORD)
-        await page.get_by_role("button", name="Acessar").click()
-        await page.wait_for_selector("text=SEJA BEM VINDO AO SISCAN")
-
-        # Navega pelo menu ate a opcao Novo Exame
-        await page.locator(
-            ".rich-ddmenu-label .rich-label-text-decor",
-            has_text="EXAME",
-        ).first.hover()
-        await page.locator(
-            ".rich-menu-item-label",
-            has_text="GERENCIAR EXAME",
-        ).click()
-        await page.locator("a.form-button", has_text="Novo Exame").click()
-        await page.wait_for_selector("label:has-text('Unidade Requisitante')")
-
-        yield page
-        await browser.close()
-
-
 def _load_data(path):
     return Validator.load_json(path)
-
-@pytest.mark.asyncio
-async def test_preencher_campos_metodo_playwright(playwright_page: Page):
-    page = playwright_page
-
-    await page.get_by_label('Mamografia').check()
-    select = page.get_by_label('Unidade Requisitante')
-    logger.debug(select)
-
-    await select.wait_for(state='attached', timeout=5000)
-
-    await select.select_option(label='0274267 - CENTRAL DE TELEATENDIMENTO SAUDE JA CURITIBA')
 
     
 # @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move Playwright-only flow to a new test file
- remove unused fixture from `test_xpath_input_types.py`
- load `cartao_sus` from fake json data in the Playwright test

## Testing
- `pytest -q` *(fails: Looks like you launched a headed browser without having a XServer running)*

------
https://chatgpt.com/codex/tasks/task_e_685bb945f6ac8321ad8e59a96088ad6f