### PR TITLE
Fix field label mapping

### DIFF
--- a/src/siscan/requisicao_exame.py
+++ b/src/siscan/requisicao_exame.py
@@ -59,14 +59,16 @@ class RequisicaoExame(SiscanWebPage):
             contendo o label, o tipo do campo e o nível de
             obrigatoriedade.
         """
-        return {
-            "cartao_sus": (
-                "Cartão SUS",
-                InputType.TEXT,
-                RequirementLevel.REQUIRED,
-            ),
+        map_label = {
+            **SiscanWebPage.MAP_DATA_LABEL,
             **RequisicaoExame.MAP_DATA_LABEL,
         }
+        map_label["cartao_sus"] = (
+            "Cartão SUS",
+            InputType.TEXT,
+            RequirementLevel.REQUIRED,
+        )
+        return map_label
 
     async def acesar_menu_gerenciar_exame(self):
         await self.acessar_menu("EXAME", "GERENCIAR EXAME")


### PR DESCRIPTION
## Summary
- include base field mappings in RequisicaoExame.get_map_label

## Testing
- `pytest -q` *(fails: Page.goto net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_685f2f48c0ac8321996b2a80b8d4b7c8