### PR TITLE
Implement JWT auth utilities and decorator

### DIFF
--- a/src/utils/decorators.py
+++ b/src/utils/decorators.py
@@ -1,0 +1,22 @@
+from functools import wraps
+
+from fastapi import Header, HTTPException
+
+from .helpers import decode_access_token
+
+
+def jwt_required(func):
+    """FastAPI route decorator to require a valid JWT token."""
+
+    @wraps(func)
+    async def wrapper(*args, authorization: str = Header(None), **kwargs):
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="missing token")
+        token = authorization.split(" ", 1)[1]
+        try:
+            decode_access_token(token)
+        except Exception:
+            raise HTTPException(status_code=401, detail="invalid token")
+        return await func(*args, **kwargs)
+
+    return wrapper

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,5 +1,62 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional
+
+import jwt
 from playwright.async_api import async_playwright
-from ..env import PRODUCTION, TAKE_SCREENSHOT
+
+from ..env import PRODUCTION, TAKE_SCREENSHOT, private_key, public_key
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+
+
+def encrypt_password(password: str) -> bytes:
+    """Encrypt a plain password using the loaded RSA public key."""
+    return public_key.encrypt(
+        password.encode(),
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+
+
+def decrypt_password(encrypted_password: bytes) -> str:
+    """Decrypt a password previously encrypted with :func:`encrypt_password`."""
+    return (
+        private_key.decrypt(
+            encrypted_password,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None,
+            ),
+        )
+        .decode()
+    )
+
+
+def verify_password(password: str, encrypted_password: bytes) -> bool:
+    """Return ``True`` if the provided password matches the encrypted one."""
+    try:
+        return decrypt_password(encrypted_password) == password
+    except Exception:
+        return False
+
+
+def create_access_token(
+    data: Dict[str, Any], expires_delta: Optional[timedelta] = None
+) -> str:
+    """Generate a JWT signed with the RSA private key."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, private_key, algorithm="RS256")
+
+
+def decode_access_token(token: str) -> Dict[str, Any]:
+    """Decode a JWT token using the RSA public key."""
+    return jwt.decode(token, public_key, algorithms=["RS256"])
 
 
 async def run_rpa(form_type, data):

--- a/tests/test_preencher_solicitacao_mamografia_endpoint.py
+++ b/tests/test_preencher_solicitacao_mamografia_endpoint.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from src.main import app
 from pathlib import Path
 from src.utils.validator import Validator
+from src.utils.helpers import create_access_token
 
 @pytest.fixture
 def client():
@@ -12,9 +13,21 @@ def client():
 def _load_data(path):
     return Validator.load_json(path)
 
-def test_solicitacao_endpoint(client, fake_json_file):
+def test_solicitacao_endpoint_requires_auth(client, fake_json_file):
     payload = _load_data(Path(fake_json_file))
     res = client.post("/preencher-solicitacao-mamografia", json=payload)
+    assert res.status_code == 401
+
+
+def test_solicitacao_endpoint(client, fake_json_file):
+    payload = _load_data(Path(fake_json_file))
+    token = create_access_token({"sub": "tester"})
+    headers = {"Authorization": f"Bearer {token}"}
+    res = client.post(
+        "/preencher-solicitacao-mamografia",
+        json=payload,
+        headers=headers,
+    )
     assert res.status_code == 200
     data = res.json()
     assert data["success"] is True


### PR DESCRIPTION
## Summary
- add RSA-based password and JWT helpers
- add decorator to validate JWT tokens
- secure `preencher-solicitacao-mamografia` route
- simplify `cadastrar-usuario` route
- test the auth requirement for the solicitation endpoint

## Testing
- `ruff check .`
- `pytest -q` *(fails: playwright network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685fe9a009108321b6b7b3c6517e41dc