### PR TITLE
Refatoração de rotas e autenticação

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Este projeto implementa uma automação (RPA) para interação com o sistema SIS
 
 - **run.py** – ponto de entrada que carrega variáveis de ambiente e executa o servidor FastAPI via Uvicorn.
 - **src/main.py** – inicializa a aplicação FastAPI e registra as rotas.
-- **src/routes.py** – define os endpoints da API:
-  - `/cadastrar-usuario` – cadastro de usuários com senha criptografada em SQLite.
-  - `/preencher-solicitacao-mamografia` – inicia o RPA para preencher uma solicitação de exame.
-  - `/preencher-laudo-mamografia` – inicia o RPA para preencher um laudo de mamografia.
+- **src/routes/** – módulos de rotas da API:
+  - `user.py` com `/user` (criação) e `/user/me` para obter o usuário autenticado.
+  - `preencher_formulario_siscan.py` com `/preencher-formulario-siscan/solicitacao-mamografia` e `/preencher-formulario-siscan/laudo-mamografia`.
+  Essas rotas aceitam autenticação via `Api-Key` (informando o UUID do usuário) ou JWT Bearer.
   Utiliza Playwright para abrir o navegador e ainda possui *TODOs* de implementação.
 - **src/siscan/** – código principal de automação:
   - `context.py` controla o navegador e coleta mensagens informativas.
@@ -50,6 +50,14 @@ Ou com Docker Compose:
 
 ```bash
 docker compose up -d --build
+```
+
+### Criar ApiKey
+
+Gere uma chave de acesso para clientes externos executando:
+
+```bash
+python cli.py create-apikey
 ```
 
 ## Rodando testes

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,27 @@
+import secrets
+
+import typer
+
+from src.env import get_db, Base, engine, init_engine
+from src.models import ApiKey
+
+app = typer.Typer(help="Utility CLI for the SIScan RPA API")
+
+
+@app.command()
+def create_apikey(db_path: str | None = None) -> None:
+    """Generate and store a new API key."""
+    if db_path:
+        init_engine(db_path)
+        Base.metadata.create_all(bind=engine)
+
+    key = secrets.token_hex(32)
+    db = get_db()
+    db.add(ApiKey(key=key))
+    db.commit()
+    db.close()
+    typer.echo(f"API key: {key}")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,10 @@
 from fastapi import FastAPI
 import logging
 from .env import Base, engine
-from .routes import router
+from .routes.user import router as user_router
+from .routes.preencher_formulario_siscan import (
+    router as formulario_router,
+)
 from . import models
 
 logging.basicConfig(
@@ -18,7 +21,8 @@ app = FastAPI(
 # Cria tabelas a partir dos models
 Base.metadata.create_all(bind=engine)
 
-app.include_router(router)
+app.include_router(user_router)
+app.include_router(formulario_router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/models.py
+++ b/src/models.py
@@ -1,11 +1,32 @@
-from sqlalchemy import Column, Integer, String, LargeBinary
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy import Column, String, LargeBinary, DateTime
 
 from .env import Base
 
 
+def one_year_from_now() -> datetime:
+    """Return a datetime one year from now."""
+    return datetime.utcnow() + timedelta(days=365)
+
+
 class User(Base):
+    """Basic user model stored with a UUID primary key."""
+
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, index=True)
+    uuid = Column(String, primary_key=True, default=lambda: str(uuid4()))
     username = Column(String, unique=True, nullable=False)
     password = Column(LargeBinary, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+
+class ApiKey(Base):
+    """Model for simple API key authentication."""
+
+    __tablename__ = "api_keys"
+
+    key = Column(String, primary_key=True)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    expires_at = Column(DateTime, default=one_year_from_now)

--- a/src/routes/preencher_formulario_siscan.py
+++ b/src/routes/preencher_formulario_siscan.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+
+from ..env import get_db
+from ..models import ApiKey
+from ..utils.helpers import run_rpa, decode_access_token
+from ..utils.schema import PreencherSolicitacaoInput
+
+router = APIRouter(prefix="/preencher-formulario-siscan", tags=["siscan"])
+
+
+def _get_user_uuid(
+    user_uuid: str | None = None,
+    api_key: str | None = Header(None, alias="Api-Key"),
+    authorization: str | None = Header(None),
+) -> str:
+    if authorization:
+        if not authorization.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="invalid token")
+        token = authorization.split(" ", 1)[1]
+        payload = decode_access_token(token)
+        return payload.get("sub")
+    if api_key:
+        db = get_db()
+        key = db.query(ApiKey).filter_by(key=api_key).first()
+        db.close()
+        if not key or key.expires_at < datetime.utcnow():
+            raise HTTPException(status_code=401, detail="invalid api key")
+        if not user_uuid:
+            raise HTTPException(status_code=400, detail="user_uuid required")
+        return user_uuid
+    raise HTTPException(status_code=401, detail="missing credentials")
+
+
+@router.post(
+    "/solicitacao-mamografia",
+    summary="Preencher Solicitação de Mamografia",
+    description="Executa o RPA para preencher a solicitação de mamografia no SIScan",
+)
+async def preencher_solicitacao(
+    data: PreencherSolicitacaoInput,
+    user_uuid: str | None = None,
+    uuid: str = Depends(_get_user_uuid),
+):
+    result = await run_rpa("solicitacao", data.__dict__)
+    result.update({"user_uuid": uuid})
+    return result
+
+
+@router.post(
+    "/laudo-mamografia",
+    summary="Preencher Laudo de Mamografia",
+    description="Executa o RPA para preencher o laudo de mamografia no SIScan",
+)
+async def preencher_laudo(
+    data: dict,
+    user_uuid: str | None = None,
+    uuid: str = Depends(_get_user_uuid),
+):
+    result = await run_rpa("laudo", data)
+    result.update({"user_uuid": uuid})
+    return result

--- a/src/routes/user.py
+++ b/src/routes/user.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, HTTPException, Depends, Header
+from sqlalchemy.exc import IntegrityError
+
+from ..env import get_db
+from ..models import User
+from ..utils.helpers import encrypt_password, decode_access_token
+from ..utils.dependencies import jwt_required
+from ..utils import messages as msg
+from ..utils.schema import CadastrarInput
+
+router = APIRouter(prefix="/user", tags=["user"])
+
+
+@router.post("", status_code=201, summary="Criar Usuário", description="Registra um novo usuário")
+def create_user(data: CadastrarInput):
+    """Cadastrar novo usuário e armazenar a senha criptografada."""
+    encrypted = encrypt_password(data.password)
+    db = get_db()
+    try:
+        db.add(User(username=data.username, password=encrypted))
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail=msg.ERR_USERNAME_EXISTS)
+    finally:
+        db.close()
+    return {"message": msg.USER_CREATED}
+
+
+@router.get("/me", summary="Usuário Autenticado", description="Retorna informações do usuário autenticado", dependencies=[Depends(jwt_required)])
+def read_me(authorization: str = Header(...)):
+    token = authorization.split(" ", 1)[1]
+    payload = decode_access_token(token)
+    db = get_db()
+    user = db.query(User).filter_by(uuid=payload.get("sub")).first()
+    db.close()
+    if not user:
+        raise HTTPException(status_code=404, detail="user not found")
+    return {
+        "uuid": user.uuid,
+        "username": user.username,
+        "created_at": user.created_at.isoformat(),
+    }

--- a/tests/test_cadastrar_usuario.py
+++ b/tests/test_cadastrar_usuario.py
@@ -19,7 +19,7 @@ def client(tmp_path):
 
 def test_register_success(client):
     res = client.post(
-        "/cadastrar-usuario", json={"username": "alice", "password": "secret"}
+        "/user", json={"username": "alice", "password": "secret"}
     )
     assert res.status_code == 201
     data = res.json()
@@ -27,13 +27,13 @@ def test_register_success(client):
 
 
 def test_register_missing_fields(client):
-    res = client.post("/cadastrar-usuario", json={"username": "bob"})
+    res = client.post("/user", json={"username": "bob"})
     assert res.status_code == 422
 
 
 def test_register_duplicate(client):
-    client.post("/cadastrar-usuario", json={"username": "eve", "password": "pwd"})
+    client.post("/user", json={"username": "eve", "password": "pwd"})
     res = client.post(
-        "/cadastrar-usuario", json={"username": "eve", "password": "pwd2"}
+        "/user", json={"username": "eve", "password": "pwd2"}
     )
     assert res.status_code == 409

--- a/tests/test_env_user_auth.py
+++ b/tests/test_env_user_auth.py
@@ -23,7 +23,7 @@ def client(tmp_path_factory):
 
 def test_create_user_env(client):
     res = client.post(
-        "/cadastrar-usuario",
+        "/user",
         json={"username": SISCAN_USER, "password": SISCAN_PASSWORD},
     )
     assert res.status_code == 201

--- a/tests/test_preencher_laudo_mamografia.py
+++ b/tests/test_preencher_laudo_mamografia.py
@@ -1,6 +1,9 @@
 import pytest
 from fastapi.testclient import TestClient
 from src.main import app
+from src.env import get_db
+from src.models import ApiKey
+import secrets
 
 
 @pytest.fixture
@@ -10,8 +13,19 @@ def client():
 
 
 def test_laudo_endpoint(client):
+    db = get_db()
+    key_value = secrets.token_hex(8)
+    db.add(ApiKey(key=key_value))
+    db.commit()
+    db.close()
+
     payload = {"campoA": "valorA", "campoB": "valorB"}
-    res = client.post("/preencher-laudo-mamografia", json=payload)
+    res = client.post(
+        "/preencher-formulario-siscan/laudo-mamografia",
+        json=payload,
+        headers={"Api-Key": key_value},
+        params={"user_uuid": "test"},
+    )
     assert res.status_code == 200
     data = res.json()
     assert data["success"] is True

--- a/tests/test_preencher_solicitacao_mamografia_endpoint.py
+++ b/tests/test_preencher_solicitacao_mamografia_endpoint.py
@@ -15,7 +15,9 @@ def _load_data(path):
 
 def test_solicitacao_endpoint_requires_auth(client, fake_json_file):
     payload = _load_data(Path(fake_json_file))
-    res = client.post("/preencher-solicitacao-mamografia", json=payload)
+    res = client.post(
+        "/preencher-formulario-siscan/solicitacao-mamografia", json=payload
+    )
     assert res.status_code == 401
 
 
@@ -24,7 +26,7 @@ def test_solicitacao_endpoint(client, fake_json_file):
     token = create_access_token({"sub": "tester"})
     headers = {"Authorization": f"Bearer {token}"}
     res = client.post(
-        "/preencher-solicitacao-mamografia",
+        "/preencher-formulario-siscan/solicitacao-mamografia",
         json=payload,
         headers=headers,
     )


### PR DESCRIPTION
## Summary
- create new API router modules for users and SIScan forms
- store users using UUID primary key and create ApiKey model
- provide CLI command `create-apikey` using Typer
- document new routes and CLI usage
- adjust tests to new endpoints and authentication

## Testing
- `pytest tests/test_preencher_solicitacao_mamografia_endpoint.py::test_solicitacao_endpoint_requires_auth -q`
- `pytest tests/test_preencher_solicitacao_mamografia_endpoint.py::test_solicitacao_endpoint -q`
- `pytest tests/test_preencher_laudo_mamografia.py::test_laudo_endpoint -q`
- `pytest -q` *(fails: Page.goto: net::ERR_TUNNEL_CONNECTION_FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_685ff29bf7c08321975b285b3ea6c87c