### PR TITLE
Add OAuth2 token endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ PyJWT==2.10.1
 typer==0.16.0
 
 ruff==0.12.1
+python-multipart

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from .routes.user import router as user_router
 from .routes.preencher_formulario_siscan import (
     router as formulario_router,
 )
+from .routes.security import router as security_router
 
 logging.basicConfig(
     level=logging.DEBUG,  # Troque para logging.INFO caso deseje menos verbosidade
@@ -22,6 +23,7 @@ Base.metadata.create_all(bind=engine)
 
 app.include_router(user_router)
 app.include_router(formulario_router)
+app.include_router(security_router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/src/routes/security.py
+++ b/src/routes/security.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+
+from ..env import get_db
+from ..models import User
+from ..utils.helpers import verify_password, create_access_token
+
+router = APIRouter(prefix="/security", tags=["security"])
+
+
+@router.post(
+    "/token",
+    summary="Gerar token JWT",
+    description="Gera um token de acesso para autenticação nos endpoints",
+)
+def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+):
+    db = get_db()
+    user = db.query(User).filter_by(username=form_data.username).first()
+    db.close()
+    if not user or not verify_password(form_data.password, user.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="incorrect username or password",
+        )
+    token = create_access_token({"sub": user.uuid})
+    return {"access_token": token, "token_type": "bearer"}

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -9,7 +9,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from fastapi.security import OAuth2PasswordBearer
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="security/token")
 
 
 def encrypt_password(password: str) -> bytes:

--- a/tests/test_security_token.py
+++ b/tests/test_security_token.py
@@ -1,0 +1,36 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.main import app
+
+
+@pytest.fixture
+def client(tmp_path):
+    db_file = tmp_path / "test.db"
+    import src.env as env
+
+    env.init_engine(str(db_file))
+    from src import models  # noqa: F401
+
+    env.Base.metadata.create_all(bind=env.engine)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_generate_token(client):
+    client.post("/user", json={"username": "alice", "password": "secret"})
+    res = client.post(
+        "/security/token",
+        data={"username": "alice", "password": "secret"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["token_type"] == "bearer"
+    assert isinstance(data["access_token"], str) and data["access_token"]
+
+
+def test_invalid_credentials(client):
+    res = client.post(
+        "/security/token",
+        data={"username": "bob", "password": "wrong"},
+    )
+    assert res.status_code == 401


### PR DESCRIPTION
## Summary
- implement `/security/token` endpoint for OAuth2 auth
- wire new router into app
- adjust OAuth2 token URL
- add python-multipart to requirements
- test token generation

## Testing
- `ruff check src/routes/security.py tests/test_security_token.py src/main.py src/utils/helpers.py`
- `pytest -q` *(fails: BrowserType.launch errors due to Playwright and missing real data)*

------
https://chatgpt.com/codex/tasks/task_e_685ffea6ae008321a054ce1c5f5d7eb5