### PR TITLE
Implement API key security

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Este projeto implementa uma automação (RPA) para interação com o sistema SIS
 - **src/main.py** – inicializa a aplicação FastAPI e registra as rotas.
 - **src/routes/** – módulos de rotas da API:
   - `user.py` com `/user` (criação) e `/user/me` para obter o usuário autenticado.
+    O endpoint `/user/me` exige autenticação JWT.
   - `preencher_formulario_siscan.py` com `/preencher-formulario-siscan/solicitacao-mamografia` e `/preencher-formulario-siscan/laudo-mamografia`.
-  Essas rotas aceitam autenticação via `Api-Key` (informando o UUID do usuário) ou JWT Bearer.
+    Esses endpoints podem ser acessados com JWT ou com `Api-Key` registrada no banco de dados (e não expirada).
   Utiliza Playwright para abrir o navegador e ainda possui *TODOs* de implementação.
 - **src/siscan/** – código principal de automação:
   - `context.py` controla o navegador e coleta mensagens informativas.


### PR DESCRIPTION
## Summary
- allow preencher_formulario endpoints to accept JWT or API key
- document authentication requirements in README

## Testing
- `ruff check src/routes/preencher_formulario_siscan.py`
- `pytest -q` *(fails: network-related playwright errors)*

------
https://chatgpt.com/codex/tasks/task_e_68600f7e4da48321899b8147d392c75c