### PR TITLE
Refactor SchemaMapExtractor to accept Pydantic models

### DIFF
--- a/src/siscan/requisicao_exame.py
+++ b/src/siscan/requisicao_exame.py
@@ -31,7 +31,7 @@ class RequisicaoExame(SiscanWebPage):
     ):
         super().__init__(base_url, user, password, schema_path)
         map_data_label, fields_map = SchemaMapExtractor.schema_to_maps(
-            schema_path, fields=RequisicaoExame.MAP_SCHEMA_FIELDS
+            self.schema_model, fields=RequisicaoExame.MAP_SCHEMA_FIELDS
         )
         RequisicaoExame.MAP_DATA_LABEL = map_data_label
         self.FIELDS_MAP.update(fields_map)

--- a/src/siscan/requisicao_exame_mamografia.py
+++ b/src/siscan/requisicao_exame_mamografia.py
@@ -85,7 +85,7 @@ class RequisicaoExameMamografia(RequisicaoExame):
         super().__init__(base_url, user, password, schema_path)
 
         map_data_label, fields_map = SchemaMapExtractor.schema_to_maps(
-            schema_path, fields=RequisicaoExameMamografia.MAP_SCHEMA_FIELDS
+            self.schema_model, fields=RequisicaoExameMamografia.MAP_SCHEMA_FIELDS
         )
         RequisicaoExameMamografia.MAP_DATA_LABEL = map_data_label
         fields_map.update(self.FIELDS_MAP)

--- a/src/siscan/siscan_webpage.py
+++ b/src/siscan/siscan_webpage.py
@@ -52,7 +52,7 @@ class SiscanWebPage(WebPage):
             "SchemaModel", Path(schema_path)
         )
         map_data_label, fields_map = SchemaMapExtractor.schema_to_maps(
-            schema_path, fields=SiscanWebPage.MAP_SCHEMA_FIELDS
+            self.schema_model, fields=SiscanWebPage.MAP_SCHEMA_FIELDS
         )
         SiscanWebPage.MAP_DATA_LABEL = map_data_label
         self.FIELDS_MAP.update(fields_map)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2,9 +2,9 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from src.utils.schema import SolicitacaoMamografiaRastreamentoSchema
-from src.utils.validator import Validator, SchemaValidationError
 
 
 def _load_data(json_path: Path) -> dict:
@@ -16,19 +16,19 @@ def _load_data(json_path: Path) -> dict:
 
 def test_validator_accepts_fake_data(fake_json_file):
     data = _load_data(Path(fake_json_file))
-    model = Validator.validate_data(data, SolicitacaoMamografiaRastreamentoSchema)
+    model = SolicitacaoMamografiaRastreamentoSchema.model_validate(data)
     assert isinstance(model, SolicitacaoMamografiaRastreamentoSchema)
 
 
 def test_validator_missing_required_field(fake_json_file):
     data = _load_data(Path(fake_json_file))
     data.pop("nome", None)
-    with pytest.raises(SchemaValidationError):
-        Validator.validate_data(data, SolicitacaoMamografiaRastreamentoSchema)
+    with pytest.raises(ValidationError):
+        SolicitacaoMamografiaRastreamentoSchema.model_validate(data)
 
 
 def test_validator_invalid_cartao_sus(fake_json_file):
     data = _load_data(Path(fake_json_file))
     data["cartao_sus"] = "12345"  # Invalid length (should be 15)
-    with pytest.raises(SchemaValidationError):
-        Validator.validate_data(data, SolicitacaoMamografiaRastreamentoSchema)
+    with pytest.raises(ValidationError):
+        SolicitacaoMamografiaRastreamentoSchema.model_validate(data)


### PR DESCRIPTION
## Summary
- allow `SchemaMapExtractor.schema_to_maps` to consume Pydantic models
- adapt `SiscanWebPage`, `RequisicaoExame` and `RequisicaoExameMamografia` to pass Pydantic models
- update `test_validator` to validate data with the Pydantic class directly

## Testing
- `pytest tests/test_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6860927a58f08321bc67849e61c42d70