### PR TITLE
Fix validator tests by rewriting fake data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,9 +119,8 @@ def fake_json_file(tmp_path_factory):
     }
 
     output_path = Path("./fake_data.json")
-
-    if not output_path.exists():
-        with open(output_path, "w", encoding="utf-8") as fp:
-            json.dump(data, fp, ensure_ascii=False, indent=2)
+    # Always rewrite the fake data file to avoid stale content between test runs
+    with open(output_path, "w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False, indent=2)
 
     return output_path


### PR DESCRIPTION
## Summary
- force regeneration of `fake_data.json` in tests

## Testing
- `pytest tests/test_validator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6861590850808321abba371aec815dea