### PR TITLE
Add headless test configuration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,17 @@ from fastapi.testclient import TestClient
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
 
+# Determine whether Playwright should run in headless mode. This can be
+# controlled via the ``HEADLESS`` environment variable. If the variable is not
+# defined, the default is ``True``.
+HEADLESS: bool = os.getenv("HEADLESS", "true").lower() == "true"
+
+
+@pytest.fixture(scope="session")
+def headless() -> bool:
+    """Return whether tests should run Playwright in headless mode."""
+    return HEADLESS
+
 ROOT = Path(__file__).resolve().parents[1]
 
 priv = ROOT / "rsa_private_key.pem"

--- a/tests/test_authenticate.py
+++ b/tests/test_authenticate.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-async def test_authenticate():
+async def test_authenticate(headless: bool):
     req = RequisicaoExameMamografiaRastreio(
         base_url=SISCAN_URL,
         user=SISCAN_USER,
@@ -19,7 +19,7 @@ async def test_authenticate():
     # Use contexto headless para nao abrir janela durante testes
     req._context = SiscanBrowserContext(
         base_url=SISCAN_URL,
-        headless=False,
+        headless=headless,
         timeout=15000,
     )
 

--- a/tests/test_env_user_auth.py
+++ b/tests/test_env_user_auth.py
@@ -41,7 +41,7 @@ def test_create_user_env(client):
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_authenticate_env_user():
+async def test_authenticate_env_user(headless: bool):
     # Captura o usuário e senha do banco de dados, tomando o usuário como chave única
     db = get_db()
     user = db.query(User).filter_by(username=SISCAN_USER).first()
@@ -69,7 +69,7 @@ async def test_authenticate_env_user():
     )
     req._context = SiscanBrowserContext(
         base_url=SISCAN_URL,
-        headless=False,
+        headless=headless,
         timeout=15000,
     )
 

--- a/tests/test_playwright_flow.py
+++ b/tests/test_playwright_flow.py
@@ -10,10 +10,10 @@ logger = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(scope="session")
-async def playwright_page():
+async def playwright_page(headless: bool):
     """Cria contexto Playwright manualmente e autentica no SIScan."""
     async with async_playwright() as p:
-        browser = await p.chromium.launch(headless=True)
+        browser = await p.chromium.launch(headless=headless)
         context = await browser.new_context(base_url=SISCAN_URL)
         page = await context.new_page()
 

--- a/tests/test_preencher_solicitacao_mamografia_diagnostica.py
+++ b/tests/test_preencher_solicitacao_mamografia_diagnostica.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_preencher_requisicao_mamografia_diagnostica():
+async def test_preencher_requisicao_mamografia_diagnostica(headless: bool):
     dados_path = Path("real_data_diagnostica.json")
 
     if not dados_path.exists():
@@ -25,7 +25,7 @@ async def test_preencher_requisicao_mamografia_diagnostica():
         base_url=SISCAN_URL, user=SISCAN_USER, password=SISCAN_PASSWORD
     )
 
-    req._context = SiscanBrowserContext(headless=True)
+    req._context = SiscanBrowserContext(headless=headless)
 
     await req.authenticate()
     await req.preencher(json_data)

--- a/tests/test_preencher_solicitacao_mamografia_rastreio.py
+++ b/tests/test_preencher_solicitacao_mamografia_rastreio.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_preencher_requisicao_mamografia_rastreamento():
+async def test_preencher_requisicao_mamografia_rastreamento(headless: bool):
     # Você precisa ter um arquivo JSON com dados reais apra preencher o formulário, certifique-se de que o caminho está correto.
     dados_path = Path("real_data_rastreamento.json")
 
@@ -27,7 +27,7 @@ async def test_preencher_requisicao_mamografia_rastreamento():
         base_url=SISCAN_URL, user=SISCAN_USER, password=SISCAN_PASSWORD
     )
 
-    req._context = SiscanBrowserContext(headless=True)
+    req._context = SiscanBrowserContext(headless=headless)
 
     await req.authenticate()
     await req.preencher(json_data)

--- a/tests/test_xpath_input_types.py
+++ b/tests/test_xpath_input_types.py
@@ -14,14 +14,14 @@ logger = logging.getLogger(__name__)
 
 
 @pytest_asyncio.fixture(scope="session")
-async def siscan_form():
+async def siscan_form(headless: bool):
     """Autentica no SIScan e navega até o formulário de novo exame."""
     req = RequisicaoExameMamografiaRastreio(
         base_url=SISCAN_URL,
         user=SISCAN_USER,
         password=SISCAN_PASSWORD,
     )
-    req._context = SiscanBrowserContext(headless=True)
+    req._context = SiscanBrowserContext(headless=headless)
 
     await req.authenticate()
     await req._novo_exame(event_button=True)


### PR DESCRIPTION
## Summary
- add HEADLESS setting and fixture in `tests/conftest.py`
- allow Playwright tests to use the common `headless` fixture

## Testing
- `pytest -q` *(fails: playwright connections blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6861ea0120d0832191375cb4c37503d2