### PR TITLE
Add x-xpath metadata and support

### DIFF
--- a/src/siscan/classes/webpage.py
+++ b/src/siscan/classes/webpage.py
@@ -204,7 +204,10 @@ class SiscanWebPage(WebPage):
         """
         xpath = menu_action()
         await (
-            await xpath.find_search_link_after_input(self.get_field_label("cartao_sus"))
+            await xpath.find_search_link_after_input(
+                self.get_field_label("cartao_sus"),
+                self.get_field_xpath("cartao_sus"),
+            )
         ).handle_click()
         await xpath.wait_page_ready()
 
@@ -251,7 +254,10 @@ class SiscanWebPage(WebPage):
         while elapsed < timeout:
             xpath.reset()
             cartao_sus_ele = await (
-                await xpath.find_form_input(self.get_field_label("cartao_sus"))
+                await xpath.find_form_input(
+                    self.get_field_label("cartao_sus"),
+                    xpath=self.get_field_xpath("cartao_sus"),
+                )
             ).wait_until_enabled()
             await cartao_sus_ele.handle_fill(numero, reset=False)
             await cartao_sus_ele.on_blur()

--- a/src/siscan/schema/requisicao_novo_exame_schema.py
+++ b/src/siscan/schema/requisicao_novo_exame_schema.py
@@ -34,7 +34,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Número do Cartão SUS (15 dígitos)",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Cartão SUS']/following-sibling::input[1]",
+            },
             max_length=15,
             min_length=15,
             title="Cartão SUS",
@@ -44,7 +47,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         Optional[str],
         Field(
             description="CPF do paciente (apenas números, 11 dígitos) - opcional",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='CPF']/following-sibling::input[1]",
+            },
             pattern="^\\d{11}$",
             title="CPF",
         ),
@@ -53,7 +59,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Nome completo do paciente",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Nome']/following-sibling::input[1]",
+            },
             min_length=1,
             title="Nome",
         ),
@@ -62,7 +71,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Nome completo da mãe do paciente",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Nome da Mãe']/following-sibling::input[1]",
+            },
             min_length=1,
             title="Nome da Mãe",
         ),
@@ -71,7 +83,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Data de nascimento no formato DD/MM/AAAA",
-            json_schema_extra={"x-widget": "date"},
+            json_schema_extra={
+                "x-widget": "date",
+                "x-xpath": "//label[normalize-space(text())='Data de Nascimento']/following-sibling::span[1]//input",
+            },
             pattern="^\\d{2}/\\d{2}/\\d{4}$",
             title="Data de Nascimento",
         ),
@@ -80,7 +95,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Nacionalidade do paciente",
-            json_schema_extra={"x-widget": "select"},
+            json_schema_extra={
+                "x-widget": "select",
+                "x-xpath": "//label[normalize-space(text())='Nacionalidade']/following-sibling::select[1]",
+            },
             title="Nacionalidade",
         ),
     ]
@@ -88,7 +106,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         Sexo,
         Field(
             description="Sexo biológico do paciente (M=Masculino, F=Feminino)",
-            json_schema_extra={"x-widget": "checkbox"},
+            json_schema_extra={
+                "x-widget": "checkbox",
+                "x-xpath": "//label[normalize-space(text())='Sexo']/following-sibling::table[1]",
+            },
             title="Sexo",
         ),
     ]
@@ -96,7 +117,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Raça/Cor declarada pelo paciente",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Raça/Cor']/following-sibling::input[1]",
+            },
             title="Raça/Cor",
         ),
     ]
@@ -104,7 +128,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Unidade Federativa (UF) com 2 letras",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='UF']/following-sibling::input[1]",
+            },
             max_length=2,
             min_length=2,
             title="UF",
@@ -114,7 +141,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Nome do município de residência",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Município']/following-sibling::input[1]",
+            },
             title="Município",
         ),
     ]
@@ -122,7 +152,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Tipo de logradouro (ex: Rua, Avenida)",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Tipo Logradouro']/following-sibling::input[1]",
+            },
             title="Tipo Logradouro",
         ),
     ]
@@ -130,7 +163,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Nome do logradouro",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Nome Logradouro']/following-sibling::input[1]",
+            },
             title="Nome Logradouro",
         ),
     ]
@@ -138,7 +174,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Número do endereço",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Numero']/following-sibling::input[1]",
+            },
             title="Numero",
         ),
     ]
@@ -146,7 +185,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Bairro de residência",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Bairro']/following-sibling::input[1]",
+            },
             title="Bairro",
         ),
     ]
@@ -154,7 +196,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="CEP (apenas números, 8 dígitos)",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Cep']/following-sibling::input[1]",
+            },
             pattern="^\\d{8}$",
             title="Cep",
         ),
@@ -163,7 +208,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         Optional[str],
         Field(
             description="Apelido do paciente (opcional)",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Apelido']/following-sibling::input[1]",
+            },
             title="Apelido",
         ),
     ] = None
@@ -171,7 +219,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         Optional[Escolaridade],
         Field(
             description="Nível de escolaridade (0=Selecione, 1=Analfabeto, 2=Ensino Fundamental Incompleto, 3=Ensino Fundamental Completo, 4=Ensino Médio Completo, 5=Ensino Superior Completo)",
-            json_schema_extra={"x-widget": "select"},
+            json_schema_extra={
+                "x-widget": "select",
+                "x-xpath": "//label[normalize-space(text())='Escolaridade:']/following-sibling::select[1]",
+            },
             title="Escolaridade:",
         ),
     ] = None
@@ -179,7 +230,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         Optional[str],
         Field(
             description="Ponto de referência (opcional)",
-            json_schema_extra={"x-widget": "text"},
+            json_schema_extra={
+                "x-widget": "text",
+                "x-xpath": "//label[normalize-space(text())='Ponto de Referência']/following-sibling::input[1]",
+            },
             title="Ponto de Referência",
         ),
     ] = None
@@ -187,7 +241,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         Optional[TipoExameMama],
         Field(
             description="Tipo de exame de mama: 01=Mamografia, 03=Cito de Mama, 05=Histo de Mama",
-            json_schema_extra={"x-widget": "radio"},
+            json_schema_extra={
+                "x-widget": "radio",
+                "x-xpath": "//fieldset[legend[normalize-space(text())='Mama']]",
+            },
             title="Mama",
         ),
     ] = None
@@ -195,7 +252,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="CNES da unidade requisitante",
-            json_schema_extra={"x-widget": "select"},
+            json_schema_extra={
+                "x-widget": "select",
+                "x-xpath": "//label[normalize-space(text())='Unidade Requisitante']/following-sibling::select[1]",
+            },
             title="Unidade Requisitante",
         ),
     ]
@@ -203,7 +263,10 @@ class RequisicaoNovoExameSchema(BaseModel):
         str,
         Field(
             description="Nome do prestador de serviço",
-            json_schema_extra={"x-widget": "select"},
+            json_schema_extra={
+                "x-widget": "select",
+                "x-xpath": "//label[normalize-space(text())='Prestador']/following-sibling::select[1]",
+            },
             title="Prestador",
         ),
     ]

--- a/src/utils/SchemaMapExtractor.py
+++ b/src/utils/SchemaMapExtractor.py
@@ -13,9 +13,11 @@ class SchemaMapExtractor:
         fields: Optional[List[str]] = None,
     ) -> Tuple[Dict[str, tuple], Dict[str, dict]]:
         """
-        Dado um JSON Schema, retorna duas tuplas:
+        Dado um JSON Schema, retorna dois dicionários:
           - MAP_DATA_LABEL: dicionário no formato esperado, restrito aos
-            campos informados (se fornecidos)
+            campos informados (se fornecidos). Cada valor é uma tupla
+            ``(label, input_type, requirement, xpath)`` onde ``xpath`` pode
+            ser ``None`` caso não esteja definido no esquema.
           - FIELDS_MAP: dicionário para campos do tipo enum, array[enum], etc.
         """
         map_data_label = {}
@@ -41,7 +43,8 @@ class SchemaMapExtractor:
             requirement = SchemaMapExtractor._infer_requirement_level(
                 field, required_fields
             )
-            map_data_label[field] = (label, input_type, requirement)
+            xpath = field_schema.get("x-xpath")
+            map_data_label[field] = (label, input_type, requirement, xpath)
             fm = SchemaMapExtractor._extract_fields_map(field_schema)
             if fm:
                 fields_map[field] = fm

--- a/src/utils/xpath_constructor.py
+++ b/src/utils/xpath_constructor.py
@@ -712,7 +712,7 @@ class XPathConstructor:
                 elapsed += interval
         raise TimeoutError(f"Timeout ao tentar selecionar o radio com value='{value}'.")
 
-    async def find_search_link_after_input(self, label_name: str) -> "XPathConstructor":
+    async def find_search_link_after_input(self, label_name: str, xpath: str | None = None) -> "XPathConstructor":
         """
         Localiza o link (<a>) de busca imediatamente após um campo input identificado pelo label.
 
@@ -724,21 +724,30 @@ class XPathConstructor:
         -------
         xpath.find_search_link_after_input("Cartão SUS").handle_click()
         """
-        await self.find_form_input(label_name, input_type=InputType.TEXT)
+        await self.find_form_input(label_name, input_type=InputType.TEXT, xpath=xpath)
         # Adiciona o seletor para o <a> logo após o campo
         self._xpath += "/following-sibling::a[1]"
         logger.debug(f"XPath para lupa após input '{label_name}': {self._xpath}")
         return self
 
     async def find_form_input(
-        self, label_name: str, input_type: str | InputType | None = None
+        self,
+        label_name: str,
+        input_type: str | InputType | None = None,
+        xpath: str | None = None,
     ) -> "XPathConstructor":
         """
         Localiza um campo de formulário pelo label e tipo, construindo o XPath adequado. Suporta diferentes estruturas HTML e tipos de input (input, select, textarea, date, checkbox, radio).
         """
         self._label = label_name
-        
+
         input_type = self._get_input_type(input_type)
+        if xpath:
+            self._xpath = xpath
+            self._input_type = input_type
+            logger.debug(f"XPath from schema: {self._xpath}")
+            return self
+
         label_xpath = f"//label[normalize-space(text())='{label_name}']"
 
         if input_type == InputType.DATE:


### PR DESCRIPTION
## Summary
- add `x-xpath` hints to `RequisicaoNovoExameSchema`
- update `SchemaMapExtractor` to parse the new key
- extend `WebPage` helpers to handle xpath metadata
- allow `XPathConstructor.find_form_input` to use explicit xpath
- adjust SIScan page logic to supply schema xpath when available

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68728196a170832694eddadafcb078f6